### PR TITLE
Fix public buckets returning NoSuchBucket without an access key + show bucket policy in console

### DIFF
--- a/alarik/Sources/Cache/BucketVersioningCache.swift
+++ b/alarik/Sources/Cache/BucketVersioningCache.swift
@@ -50,6 +50,12 @@ final actor BucketVersioningCache {
         map.removeValue(forKey: bucketName)
     }
 
+    /// Whether a bucket with this name exists at all - unlike the access-key -> bucket map, this
+    /// covers every bucket (added on create, removed on delete, loaded from all buckets at boot).
+    func exists(_ bucketName: String) -> Bool {
+        map[bucketName] != nil
+    }
+
     /// Check if versioning is enabled for a bucket
     func isVersioningEnabled(for bucketName: String) -> Bool {
         map[bucketName] == .enabled

--- a/alarik/Sources/Controllers/Internal/InternalAdminController.swift
+++ b/alarik/Sources/Controllers/Internal/InternalAdminController.swift
@@ -77,6 +77,9 @@ struct InternalAdminController: RouteCollection {
         let creationDate: Date?
         let versioningStatus: String
         let user: User.ResponseDTO?
+        /// Raw JSON bucket policy document, or nil if no policy is set - drives the admin list's
+        /// public/private badge and pre-fills the policy editor.
+        let policy: String?
     }
 
     func boot(routes: any RoutesBuilder) throws {
@@ -233,7 +236,8 @@ struct InternalAdminController: RouteCollection {
         return page.map {
             AdminBucketDTO(
                 id: $0.id, name: $0.name, creationDate: $0.creationDate,
-                versioningStatus: $0.versioningStatus, user: $0.user.toResponseDTO())
+                versioningStatus: $0.versioningStatus, user: $0.user.toResponseDTO(),
+                policy: $0.policy)
         }
     }
 

--- a/alarik/Sources/Models/S3/Bucket+DTO.swift
+++ b/alarik/Sources/Models/S3/Bucket+DTO.swift
@@ -130,7 +130,8 @@ final class Bucket: Content, Model, @unchecked Sendable {
             id: self.id,
             name: self.$name.value,
             creationDate: self.creationDate,
-            versioningStatus: self.versioningStatus
+            versioningStatus: self.versioningStatus,
+            policy: self.policy
         )
     }
 
@@ -156,6 +157,9 @@ extension Bucket {
         var name: String?
         var creationDate: Date?
         var versioningStatus: String?
+        /// Raw JSON bucket policy document, or nil if no policy is set - lets the console pre-fill
+        /// the policy editor and show a public/private indicator instead of always looking empty.
+        var policy: String?
 
         func toModel() -> Bucket {
             let model = Bucket()
@@ -170,6 +174,7 @@ extension Bucket {
             if let versioningStatus = self.versioningStatus {
                 model.versioningStatus = versioningStatus
             }
+            model.policy = self.policy
             return model
         }
     }

--- a/alarik/Sources/Services/S3Service.swift
+++ b/alarik/Sources/Services/S3Service.swift
@@ -78,7 +78,12 @@ struct S3Service {
     }
 
     static func verifyBucketExists(_ bucketName: String, requestId: String) async throws {
-        guard await AccessKeyBucketMapCache.shared.bucket(for: bucketName) != nil else {
+        // Existence must NOT come from the access-key -> bucket map: that map only covers buckets
+        // some access key is mapped to, so a bucket owned by a user who never created an access key
+        // (e.g. one created + managed entirely through the console) reads as missing. That 404s the
+        // anonymous public-read path before it ever consults the bucket policy. Authorization is
+        // still enforced separately (canAccess / bucket policy).
+        guard await BucketVersioningCache.shared.exists(bucketName) else {
             throw S3Error(
                 status: .notFound, code: "NoSuchBucket",
                 message: "The specified bucket does not exist.", requestId: requestId)

--- a/alarik/Tests/Services/BucketServiceTests.swift
+++ b/alarik/Tests/Services/BucketServiceTests.swift
@@ -215,4 +215,29 @@ struct BucketServiceTests {
             #expect(remaining == 0)
         }
     }
+
+    @Test("verifyBucketExists succeeds for a bucket owned by a user with no access keys (regression: anonymous public-read must not 404)")
+    func testVerifyBucketExistsWithoutAccessKey() async throws {
+        try await withApp { app in
+            // A user who has never created an S3 access key - the exact situation of someone who
+            // creates and manages a bucket entirely through the web console.
+            let userId = try await createUser(app)
+            let bucketName = "no-access-key-bucket"
+
+            try await BucketService.create(on: app.db, bucketName: bucketName, userId: userId)
+
+            // Precondition that reproduces the original bug: no access key maps to this bucket,
+            // so the old existence check (AccessKeyBucketMapCache) would have reported it missing.
+            #expect(await AccessKeyBucketMapCache.shared.bucket(for: bucketName) == nil)
+
+            // The fix: existence is access-key-independent, so this must NOT throw NoSuchBucket.
+            try await S3Service.verifyBucketExists(bucketName, requestId: "test-request")
+
+            // A genuinely absent bucket still throws NoSuchBucket.
+            await #expect(throws: S3Error.self) {
+                try await S3Service.verifyBucketExists(
+                    "definitely-missing-bucket", requestId: "test-request")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes two things around public buckets / bucket policies.

A bucket returned `NoSuchBucket` for anonymous requests when its owner had no access key. `verifyBucketExists` was checking existence against `AccessKeyBucketMapCache`, which only knows buckets that have an access key attached, so console-created buckets looked like they didn't exist and the public-read policy never ran. Switched it to `BucketVersioningCache`, which tracks every bucket.

Also added the `policy` field to `Bucket.ResponseDTO` and `AdminBucketDTO` so the console policy editor shows the saved policy and the admin badge reflects public/private (before, the field wasn't returned so the editor opened empty and the badge always said Private).

Added a regression test for the existence check.

Closes #16